### PR TITLE
Improve ONVIF auth handling and RTSP fallback

### DIFF
--- a/tests/test_onvif_utils.py
+++ b/tests/test_onvif_utils.py
@@ -1,3 +1,4 @@
+import pathlib
 import sys
 import types
 import unittest
@@ -44,6 +45,8 @@ def _install_cv2_stub():
 
 
 _install_cv2_stub()
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
 import onvif_utils
 


### PR DESCRIPTION
## Summary
- expose ONVIF media capability and method visibility information in the main report and annotate insufficient privileges
- refine ONVIF authentication reporting to detect limited media access while keeping credential discovery stable
- harden ffprobe fallback by retrying without -stimeout when unsupported and update tests to import the project root reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d074cbe21c832686eb6654345bfd65