### PR TITLE
Handle WRONG_CREDS verdict when authentication grants no extra methods

### DIFF
--- a/onvif_utils.py
+++ b/onvif_utils.py
@@ -557,6 +557,7 @@ def try_onvif_connection(
     )
 
     auth_summary = auth_phase["summary"]
+    anon_open = set(anonymous_phase["summary"].get("open", []))
     auth_open = set(auth_summary["open"])
     auth_unauthorized = set(auth_summary["unauthorized"])
     auth_not_supported = set(auth_summary["not_supported"])
@@ -586,7 +587,13 @@ def try_onvif_connection(
             else:
                 final_verdict = "LIMITED_ONVIF"
         else:
-            if auth_unauthorized or "unauthorized" in error_categories:
+            if (
+                auth_open <= anon_open
+                and auth_open
+                and (auth_unauthorized or "unauthorized" in error_categories)
+            ):
+                final_verdict = "WRONG_CREDS"
+            elif auth_unauthorized or "unauthorized" in error_categories:
                 final_verdict = "INSUFFICIENT_ROLE"
             elif media_denied:
                 final_verdict = "INSUFFICIENT_ROLE"


### PR DESCRIPTION
## Summary
- track the methods accessible anonymously when evaluating ONVIF authentication
- treat authentication attempts that do not open new methods and return unauthorized responses as WRONG_CREDS instead of INSUFFICIENT_ROLE

## Testing
- python -m compileall onvif_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d08dc2c0c4832681979b881afd261e