### PR TITLE
Fix ONVIF WS-Security handling and classify security token faults

### DIFF
--- a/tests/test_onvif_utils.py
+++ b/tests/test_onvif_utils.py
@@ -1,0 +1,27 @@
+import unittest
+
+from onvif_utils import _classify_category
+
+
+class ClassifyCategoryTests(unittest.TestCase):
+    def test_security_token_fault_is_unauthorized(self):
+        message = "The security token could not be authenticated or authorized"
+        self.assertEqual(
+            _classify_category(None, message, exc=None),
+            "unauthorized",
+        )
+
+    def test_fault_code_failed_authentication_is_unauthorized(self):
+        class DummyFault:
+            def __init__(self):
+                self.code = "wsse:FailedAuthentication"
+
+        dummy = DummyFault()
+        self.assertEqual(
+            _classify_category(None, "", exc=dummy),
+            "unauthorized",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep the post-discovery ONVIF client in WS-Security mode in camcheck and only retry without digest when authentication faults are detected
- treat WS-Security "security token" and FailedAuthentication faults as unauthorized and expose GetStreamUri diagnostics for RTSP fallback analysis
- add unit coverage that exercises the new unauthorized classification cases

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68e2bcaa5cf08326b5a96038ef05d51a